### PR TITLE
Fix #flatten on Arrays that contain a Hashery::OpenCascade

### DIFF
--- a/lib/hashery/open_cascade.rb
+++ b/lib/hashery/open_cascade.rb
@@ -114,6 +114,10 @@ module Hashery
       end
     end
 
+    def respond_to?(sym, include_private = false)
+      sym != :to_ary && super
+    end
+
     #def each
     #  super do |key, entry|
     #    yield([key, transform_entry(entry)])

--- a/test/case_open_cascade.rb
+++ b/test/case_open_cascade.rb
@@ -108,3 +108,15 @@ testcase Hash do
   end
 
 end
+
+testcase Array do
+
+  method :flatten do
+    test "array can be flattened if contains OpenCascade" do
+      cascade = OpenCascade[:foo=>"bar"]
+      array = [cascade]
+      array.flatten # should not raise error
+    end
+  end
+
+end


### PR DESCRIPTION
Fixes `can't convert Hashery::OpenCascade to Array (Hashery::OpenCascade#to_ary gives Hashery::OpenCascade)` when calling `Array#flatten` on an `Array` that contains a `Hashery::OpenCascade`

Might be ruby 1.9 thing.
